### PR TITLE
Fixed .navbar-right issue in kc-nav.less

### DIFF
--- a/src/less/kc-nav.less
+++ b/src/less/kc-nav.less
@@ -145,6 +145,9 @@ header .navbar {
     #nav-right-lg{
         .make-md-column(9);
         margin-top:12px;
+        .navbar-right {
+            margin-right:0;
+        }
         .navbar-inverse {
             background-color:transparent;
             border:none;


### PR DESCRIPTION
The Search box was hanging 20px over in large screens. Check here: http://proto.kingcounty.gov/bs3/theme-default.html and compare to www.kingcounty.gov
